### PR TITLE
Support unique indexes

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -1,0 +1,57 @@
+# Trigger this workflow only to manually create a Docker release; this should only be used
+# in extraordinary circumstances, as Docker releases are normally created automatically as
+# part of the automated release workflow.
+
+name: release-manual-docker
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        default: ''
+        description: 'Reference (tag / SHA):'
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: cercle/parse-server
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Determine branch name
+        id: branch
+        run: echo "::set-output name=branch_name::${GITHUB_REF#refs/*/}"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref }}
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Log into Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: cercle
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=${{ steps.branch.outputs.branch_name == 'release' && github.event.inputs.ref == '' }}
+          tags: |
+            type=semver,enable=true,pattern={{version}},value=${{ github.event.inputs.ref }}
+            type=raw,enable=${{ github.event.inputs.ref == '' }},value=latest
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build stage
-FROM node:lts-alpine as build
+# Build seems to be broken in lts.
+# Probably due to existing package-lock.json still relying on npm v6
+FROM node:14-alpine as build
 
 RUN apk update; \
   apk add git;
@@ -10,7 +12,7 @@ COPY . .
 RUN npm run build
 
 # Release stage
-FROM node:lts-alpine as release
+FROM node:14-alpine as release
 
 RUN apk update; \
   apk add git;

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -364,6 +364,21 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
     expect(schemaAfterDeletion.fields.test).toBeUndefined();
   });
 
+  it('should create unique index', async () => {
+    const database = Config.get(Parse.applicationId).database;
+    const obj = new Parse.Object('MyObject');
+    obj.set('test', 1);
+    await obj.save();
+    new Parse.Schema('MyObject').addIndex('MyObject_test_1', {
+      test: 1,
+      __op: 'AddUnique',
+    });
+
+    const postIndexPlan = await database.find('MyObject', { test: 1 });
+
+    expect(postIndexPlan[0].test).toEqual(1);
+  });
+
   if (
     semver.satisfies(process.env.MONGODB_VERSION, '>=4.0.4') &&
     process.env.MONGODB_TOPOLOGY === 'replicaset' &&

--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -159,11 +159,21 @@ export default class MongoCollection {
     return this._mongoCollection.deleteMany(query, { session });
   }
 
-  _ensureSparseUniqueIndexInBackground(indexRequest) {
+  // An optional second parameter to pass down the uniqueIndexName
+  // Needed as Parse Server manages its own index metadata its record has to
+  // match the index names in the db
+  // TODO: Pass it in first parameter be default?
+  // Perhaps by constructing the first parameter to createIndex below manually
+  _ensureSparseUniqueIndexInBackground(indexRequest, uniqueIndexName) {
     return new Promise((resolve, reject) => {
       this._mongoCollection.createIndex(
         indexRequest,
-        { unique: true, background: true, sparse: true },
+        {
+          unique: true,
+          background: true,
+          sparse: true,
+          ...(uniqueIndexName ? { name: uniqueIndexName } : {}),
+        },
         error => {
           if (error) {
             reject(error);


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: Support adding Unique Indexes through Parse.Schema().addIndex in Parse Server 4.x.x

### Approach
<!-- Add a description of the approach in this PR. -->
When calling Parse.Schema.addIndex(), pass a `__op: 'AddUnique'` key-value pair in the second argument, the index. Indexes made this way are created using a call to MongoStorageAdapter.ensureUniqueness(), which has also been slightly modified to take the indexName as an extra argument.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete suggested TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
